### PR TITLE
Feature flag demo implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,31 +92,31 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-<!-- TEST -->
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.togglz</groupId>
 			<artifactId>togglz-spring-boot-starter</artifactId>
 			<version>2.6.1.Final</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.togglz</groupId>
 			<artifactId>togglz-spring-security</artifactId>
 			<version>2.6.1.Final</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.togglz</groupId>
 			<artifactId>togglz-console</artifactId>
 			<version>2.6.1.Final</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.togglz</groupId>
+			<artifactId>togglz-junit</artifactId>
+			<version>2.6.1.Final</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,31 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+<!-- TEST -->
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.togglz</groupId>
+			<artifactId>togglz-spring-boot-starter</artifactId>
+			<version>2.6.1.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.togglz</groupId>
+			<artifactId>togglz-spring-security</artifactId>
+			<version>2.6.1.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.togglz</groupId>
+			<artifactId>togglz-console</artifactId>
+			<version>2.6.1.Final</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/quickndirty/minisurveymonkey/ApplicationFeatures.java
+++ b/src/main/java/quickndirty/minisurveymonkey/ApplicationFeatures.java
@@ -1,0 +1,17 @@
+package quickndirty.minisurveymonkey;
+import org.springframework.context.annotation.Bean;
+import org.togglz.core.Feature;
+import org.togglz.core.annotation.EnabledByDefault;
+import org.togglz.core.annotation.Label;
+import org.togglz.core.context.FeatureContext;
+import org.togglz.core.manager.EnumBasedFeatureProvider;
+import org.togglz.core.spi.FeatureProvider;
+
+public enum ApplicationFeatures implements Feature {
+    @EnabledByDefault
+    @Label("Provide graphical display of results for survey responses")
+    GRAPHICAL_RESPONSES;
+    public boolean isActive() {
+        return FeatureContext.getFeatureManager().isActive(this);
+    }
+}

--- a/src/main/java/quickndirty/minisurveymonkey/WebController.java
+++ b/src/main/java/quickndirty/minisurveymonkey/WebController.java
@@ -120,6 +120,9 @@ public class WebController {
         if (featureManager.isActive(ApplicationFeatures.GRAPHICAL_RESPONSES)) {
             model.addAttribute("featureVar", "GRAPHICAL_RESPONSES");
         }
+        else{
+            model.addAttribute("featureVar", "BASIC_RESPONSES");
+        }
         return "surveyResponse";
     }
 

--- a/src/main/java/quickndirty/minisurveymonkey/WebController.java
+++ b/src/main/java/quickndirty/minisurveymonkey/WebController.java
@@ -9,11 +9,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.togglz.core.manager.FeatureManager;
 
 import java.util.*;
 
 @Controller
 public class WebController {
+
+    @Autowired
+    private FeatureManager featureManager;
 
     @Autowired
     private SurveyRepository surveyRepository;
@@ -113,6 +117,9 @@ public class WebController {
         model.addAttribute("questions", survey.getQuestions());
         model.addAttribute("results", resultsMap);
         model.addAttribute("name", survey.getName());
+        if (featureManager.isActive(ApplicationFeatures.GRAPHICAL_RESPONSES)) {
+            model.addAttribute("featureVar", "GRAPHICAL_RESPONSES");
+        }
         return "surveyResponse";
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,9 @@ spring.security.oauth2.client.registration.github.clientSecret=5f477ba27e79f51f6
 spring.security.oauth2.client.registration.google.client-id=792206189231-urhbgs94kbrphlvf9re4vhqg5sehiv9o.apps.googleusercontent.com
 spring.security.oauth2.client.registration.google.clientSecret=4dp0674QfTmePgraejhkoX5h
 
+## Feature Togglz
+togglz.console.enabled=true
+togglz.console.secured=false
+togglz.feature-enums=quickndirty.minisurveymonkey.ApplicationFeatures
+togglz.console.use-management-port=false
+togglz.console.path=/togglz-console

--- a/src/main/resources/templates/surveyResponse.html
+++ b/src/main/resources/templates/surveyResponse.html
@@ -12,9 +12,14 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>
+
     <nav class="navbar navbar-dark bg-dark">
         <a class="navbar-brand" href="#" th:text="'Responses for ' + ${name}"></a>
     </nav>
+    <div th:switch="${featureVar}">
+        <p hidden th:case="GRAPHICAL_RESPONSES" th:text="${featureVar}"></p>
+        <p hidden th:case="BASIC_RESPONSES" th:text="${featureVar}"></p>
+    </div>
     <div class="container-flex">
         <div class="">
             <div class="row justify-content-center" th:each="question : ${questions}">

--- a/src/main/resources/templates/surveyResponse.html
+++ b/src/main/resources/templates/surveyResponse.html
@@ -16,10 +16,7 @@
     <nav class="navbar navbar-dark bg-dark">
         <a class="navbar-brand" href="#" th:text="'Responses for ' + ${name}"></a>
     </nav>
-    <div th:switch="${featureVar}">
-        <p hidden th:case="GRAPHICAL_RESPONSES" th:text="${featureVar}"></p>
-        <p hidden th:case="BASIC_RESPONSES" th:text="${featureVar}"></p>
-    </div>
+    <p hidden th:text="${featureVar}"></p>
     <div class="container-flex">
         <div class="">
             <div class="row justify-content-center" th:each="question : ${questions}">

--- a/src/main/resources/templates/surveyResponse.html
+++ b/src/main/resources/templates/surveyResponse.html
@@ -5,7 +5,7 @@
 <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.bundle.js"></script>
-<script src="/js/responseSurvey.js"></script>
+<script th:if="${featureVar} == 'GRAPHICAL_RESPONSES'" src="/js/responseSurvey.js"></script>
 <link rel="stylesheet" type="text/css" href="/css/answerSurvey.css">
 <head>
     <title th:text="${name}"></title>
@@ -23,7 +23,7 @@
                         <div th:switch="${question.type}">
                             <div th:case="${T(quickndirty.minisurveymonkey.QuestionType).TEXT}" class="question-container" data-question-type="TEXT">
                                 <h2 th:text="${question.prompt}"></h2>
-                                <table class="table table-striped table-bordered table-hover table-dark">
+                                <table class="table table-striped table-bordered table-hover">
                                     <thead>
                                         <tr><th>All Responses</th></tr>
                                     </thead>
@@ -34,7 +34,7 @@
                             </div><br><br>
                             <div th:case="${T(quickndirty.minisurveymonkey.QuestionType).NUMBER}" class="question-container" data-question-type="NUMBER" th:data-question-min="${question.min}" th:data-question-max="${question.max}">
                                 <h2 th:text="${question.prompt} + ' - Between ' + ${question.min} + ' and ' + ${question.max}"></h2>
-                                <table class="table table-striped table-bordered table-hover table-dark">
+                                <table class="table table-striped table-bordered table-hover">
                                     <thead>
                                         <tr><th>Range Value</th><th># of occurrences</th></tr>
                                     </thead>
@@ -45,7 +45,7 @@
                             </div><br><br>
                             <div th:case="${T(quickndirty.minisurveymonkey.QuestionType).MC}" class="question-container" data-question-type="MC">
                                 <h2 th:text="${question.prompt}"></h2>
-                                <table class="table table-striped table-bordered table-hover table-dark">
+                                <table class="table table-striped table-bordered table-hover">
                                     <thead>
                                         <tr><th>Choice</th><th># of occurrences</th></tr>
                                     </thead>
@@ -56,7 +56,7 @@
                             </div><br><br>
                         </div>
                     </ul>
-                <div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/test/java/quickndirty/minisurveymonkey/FeatureToggleTest.java
+++ b/src/test/java/quickndirty/minisurveymonkey/FeatureToggleTest.java
@@ -1,0 +1,24 @@
+package quickndirty.minisurveymonkey;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.togglz.junit.TogglzRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FeatureToggleTest {
+    @Rule
+    public TogglzRule togglzRule = TogglzRule.allEnabled(ApplicationFeatures.class);
+
+    @Test
+    public void testDefaultEnabledFeature() {
+        assertTrue(ApplicationFeatures.GRAPHICAL_RESPONSES.isActive());
+    }
+
+    @Test
+    public void testDefaultDisabledFeature() {
+        togglzRule.disable(ApplicationFeatures.GRAPHICAL_RESPONSES);
+        assertFalse(ApplicationFeatures.GRAPHICAL_RESPONSES.isActive());
+    }
+}


### PR DESCRIPTION
This PR contains the implementation of a feature toggle for the demo of the feature toggle pattern, for issue #55 . It uses Togglz [https://www.togglz.org](url) Spring integration. Tests have been included to check that the feature is being enabled and disabled.

Togglz admin console has been enabled, can be reached at the /togglz-console endpoint on a running server. Here the feature flag can be toggled to be enabled or disabled, and changes take effect instantly, no need to redeploy.

The feature I implemented either adds or removes the JavaScript file used to generate charts on the response page of a survey. It is enabled by default to generate the charts. Below is an example of the toggle in use.

When feature is enabled:
![image](https://user-images.githubusercontent.com/19558270/77607583-32ff7e80-6ef1-11ea-81a6-91484285bf92.png)

When feature is disabled
![image](https://user-images.githubusercontent.com/19558270/77607632-575b5b00-6ef1-11ea-9861-a70a3621c116.png)
